### PR TITLE
Rolling menu and a global menu item list

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -19,8 +19,8 @@
 #define WIFI_AP_SSID    "Watchy AP"
 
 // menu
-#define MENU_HEIGHT     25
-#define MENU_LENGTH     7
+#define MENU_ITEM_HEIGHT  25
+#define MENU_LENGTH       8
 
 // set time
 #define SET_HOUR   0

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -68,7 +68,7 @@ void button_wakeup() {
 }
 
 void handle_menu(int menu_index) {
-  if (menu_index <= 0 || menu_index >= MENU_LENGTH) {
+  if (menu_index < 0 || menu_index >= MENU_LENGTH) {
     return;
   }
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1,4 +1,5 @@
 #include "gui.h"
+#include "menu_items.h"
 #include <GxEPD2_BW.h>
 
 #include "face.h"
@@ -8,16 +9,7 @@
 #include "hardware/hardware.h"
 #include "hardware/motor.h"
 #include "hardware/rtc_sram.h"
-#include "hardware/wifi.h"
-
-#include "app/about.h"
-#include "app/accelerometer.h"
-#include "app/buzz.h"
-#include "app/ntp.h"
-#include "app/set_time.h"
-#include "app/timer.h"
 #include "app/update.h"
-#include "app/weather.h"
 
 void gui_setup() {
   switch (wake_up_reason) {
@@ -75,6 +67,19 @@ void button_wakeup() {
   }
 }
 
+void handle_menu(int menu_index) {
+  if (menu_index <= 0 || menu_index >= MENU_LENGTH) {
+    return;
+  }
+
+  menu_item_t menu_item = menu_items[menu_index];
+  menu_item.handler();
+
+  if(menu_item.exit_after_handler) {
+    show_menu(menu_index, menu_item.partial_refresh);
+  }
+}
+
 void menu_button_handler() {
   switch (gui_state) {
     case WATCHFACE_STATE:
@@ -84,37 +89,7 @@ void menu_button_handler() {
     case MAIN_MENU_STATE:
       // If already in menu, then select menu item
       gui_state = APP_STATE;
-      switch (menuIndex) {
-        case 0:
-          timer_app_main();
-          break;
-        case 1:
-          about_app_main();
-          break;
-        case 2:
-          showBuzz();
-          show_menu(menuIndex, false);
-          break;
-        case 3:
-          accelerometer_app_main();
-          show_menu(menuIndex, true);
-          break;
-        case 4:
-          set_time_app_main();
-          show_menu(menuIndex, true);
-          break;
-        case 5:
-          setupWifi();
-          break;
-        case 6:
-          showUpdateFW();
-          break;
-        case 7:
-          showSyncNTP();
-          break;
-        default:
-          break;
-      }
+      handle_menu(menuIndex);
       break;
     case FW_UPDATE_STATE:
       updateFWBegin();

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -1,49 +1,56 @@
 #include "menu.h"
 #include "gui.h"
+#include "menu_items.h"
 #include "hardware/hardware.h"
 #include "hardware/rtc_sram.h"
 #include <Fonts/FreeMonoBold9pt7b.h>
 
-#define MENU_ITEM_HEIGHT  25
-
-const char *menuItems[] = {
-  "Timer",
-  "About",
-  "Vibrate Motor",
-  "Show Accelerometer",
-  "Set Time",
-  "Setup WiFi",
-  "Update Firmware",
-  "Sync NTP"
-};
-
 void show_menu(byte menuIndex, bool partialRefresh) {
   display.setFullWindow();
   display.fillScreen(GxEPD_BLACK);
-  draw_menu(menuItems, 7, menuIndex);
+  draw_menu(menuIndex);
   display.display(partialRefresh);
   gui_state = MAIN_MENU_STATE;
   alreadyInMenu = false;
 }
 
-void draw_menu(const char* menu_items[], uint8_t menu_length, uint8_t menu_index) {
+void draw_menu(uint8_t menu_index) {
   display.setFont(&FreeMonoBold9pt7b);
 
   int16_t x1, y1;
   uint16_t w, h;
   int16_t yPos;
 
-  for (int i = 0; i < menu_length; i++) {
-    yPos = MENU_ITEM_HEIGHT + (MENU_ITEM_HEIGHT * i);
+  static uint8_t top_window = 0;
+  static uint8_t bottom_window = MAX_MENU_ITEMS_ON_SCREEN;
+
+  if (menu_index < top_window) {
+    top_window = menu_index;
+    bottom_window = top_window + MAX_MENU_ITEMS_ON_SCREEN;
+  } else if (menu_index >= bottom_window) {
+    bottom_window = menu_index + 1;
+    top_window = bottom_window - MAX_MENU_ITEMS_ON_SCREEN;
+  }
+
+  for (int i = 0; i < MAX_MENU_ITEMS_ON_SCREEN; i++) {
+    if (i + top_window >= MENU_LENGTH) {
+      break;
+    }
+
+    uint8_t m_index = i + top_window;
+    
+    yPos = MENU_ITEM_HEIGHT * i;
     display.setCursor(0, yPos);
-    if (i == menu_index) {
-      display.getTextBounds(menu_items[i], 0, yPos, &x1, &y1, &w, &h);
-      display.fillRect(x1 - 1, y1 - 10, 200, h + 15, GxEPD_WHITE);
+    display.getTextBounds(menu_items[m_index].title, 0, yPos, &x1, &y1, &w, &h);
+
+    if (m_index == menu_index) {
+      display.fillRect(0, yPos, DISPLAY_WIDTH, MENU_ITEM_HEIGHT, GxEPD_WHITE);
       display.setTextColor(GxEPD_BLACK);
-      display.println(menu_items[i]);
     } else {
       display.setTextColor(GxEPD_WHITE);
-      display.println(menu_items[i]);
     }
+
+    display.setCursor(0, yPos + MENU_ITEM_HEIGHT - (h / 2));
+    display.println(menu_items[m_index].title);
   }
 }

--- a/src/gui/menu.h
+++ b/src/gui/menu.h
@@ -3,4 +3,4 @@
 #include <Arduino.h>
 
 void show_menu(byte menuIndex, bool partialRefresh);
-void draw_menu(const char* menu_items[], uint8_t menu_length, uint8_t menu_index);
+void draw_menu(uint8_t menu_index);

--- a/src/gui/menu_item.cpp
+++ b/src/gui/menu_item.cpp
@@ -1,0 +1,22 @@
+#include "menu_items.h"
+
+#include "app/about.h"
+#include "app/accelerometer.h"
+#include "app/buzz.h"
+#include "app/ntp.h"
+#include "app/set_time.h"
+#include "app/timer.h"
+#include "app/update.h"
+#include "app/weather.h"
+#include "hardware/wifi.h"
+
+menu_item_t menu_items[] = {
+    {"Timer", timer_app_main, false, false},
+    {"About", about_app_main, false, false},
+    {"Vibrate Motor", showBuzz, true, false},
+    {"Show Accelerometer", accelerometer_app_main, true, true},
+    {"Set Time", set_time_app_main, true, true},
+    {"Setup WiFi", setupWifi, false, false},
+    {"Update Firmware", showUpdateFW, false, false},
+    {"Sync NTP", showSyncNTP, false, false}
+};

--- a/src/gui/menu_items.h
+++ b/src/gui/menu_items.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "config.h"
+
+#define MAX_MENU_ITEMS_ON_SCREEN (DISPLAY_HEIGHT / MENU_ITEM_HEIGHT)
+
+/**
+ * Struct for a menu item
+ */
+typedef struct {
+    const char *title;
+    void (*handler)();
+    bool exit_after_handler;
+    bool partial_refresh;
+} menu_item_t;
+
+/**
+ * Array of menu items, defined in menu_items.cpp
+ */
+extern menu_item_t menu_items[];


### PR DESCRIPTION
This PR includes the following:

- Adds a new struct `menu_item_t`. This struct keeps all the handlers and titles in one place.
- Replaces the current way of rendering the menu, it now renders what the variable `menu_items` defines.
- Implements a simple rolling menu, i.e. allows for more than 7/8 items to be shown to the user.
- Cleanups header includes

Overall, the aim of this PR is to allow users to create new menu items/app/widgets without touching too much of the codebase.